### PR TITLE
Fix coveralls coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ python:
   - "3.6"
   - "3.7-dev"
   - "pypy3"
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
+
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
 before_script:
   - cd src
 script:
-  - pytest ../tests/
-after_script:
+  - coverage run --source . -m pytest ../tests/
+after_success:
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
 toml
-python-coveralls
-coveralls


### PR DESCRIPTION
- don't list coveralls as a project dep and install it separately in travis
- don't install python-coveralls at all
- run `pytest` under `coverage`
- change `after_script` to `after_success`